### PR TITLE
[Fix] Adapted type specs

### DIFF
--- a/lib/agora/access_key.ex
+++ b/lib/agora/access_key.ex
@@ -146,7 +146,7 @@ defmodule Agora.AccessKey do
           binary,
           binary,
           binary,
-          [atom()],
+          [{atom(), integer()}],
           integer(),
           integer()
         ) :: binary()


### PR DESCRIPTION
The type spec was not set correctly for the public function `Agora.AccessKey.generate_signed_token/7` and was throwing dialyzer errors in my downstream application.

I adapted the spec to match the data that is passed in. Hope it helps :)