### PR TITLE
Fix bitstring type hint for concatenation

### DIFF
--- a/lib/agora/access_key.ex
+++ b/lib/agora/access_key.ex
@@ -93,7 +93,7 @@ defmodule Agora.AccessKey do
         expires_at::unsigned-integer-size(32)-little
       >>
 
-      acc <> privilege_binary
+      << acc :: bitstring >> <> privilege_binary
     end)
   end
 

--- a/lib/agora/access_key.ex
+++ b/lib/agora/access_key.ex
@@ -93,7 +93,7 @@ defmodule Agora.AccessKey do
         expires_at::unsigned-integer-size(32)-little
       >>
 
-      << acc :: bitstring >> <> privilege_binary
+      << acc::bitstring >> <> privilege_binary
     end)
   end
 


### PR DESCRIPTION
Sometimes the access tokens were incorrect, e.g. sometimes the message length was 14 instead of expected 16. I found out that the type hint was not set for the accumulator. This ensures that the accumulator is treated as a bitstring rather than binary.