### PR TITLE
Fix missing :crypto.hmac/3 function

### DIFF
--- a/lib/agora/access_key.ex
+++ b/lib/agora/access_key.ex
@@ -181,7 +181,7 @@ defmodule Agora.AccessKey do
   end
 
   defp sign(key, value) do
-    :crypto.hmac(:sha256, key, value)
+    :crypto.mac(:hmac, :sha256, key, value)
   end
 
   defp crc32(data), do: :erlang.crc32(data)


### PR DESCRIPTION
After updating to OTP 24 the :crypto.hmac/3 function seems to be missing, so I changed it to :crypto.mac/4 and it seems to work as it did before. :crypto.mac/4 seems to have been there since 22.1 according to the docs.